### PR TITLE
fix overriding parameters in Wagtail 2.12.2

### DIFF
--- a/wagtailyoast/edit_handlers.py
+++ b/wagtailyoast/edit_handlers.py
@@ -33,3 +33,10 @@ class YoastPanel(ObjectList):
             ], heading="Page")
         ]
         super().__init__(children=children, heading=heading)
+
+    def clone_kwargs(self):
+        kwargs = super().clone_kwargs()
+        kwargs['title'] = self.title_field
+        kwargs['search_description'] = self.search_description
+        kwargs['slug'] = self.slug
+        return kwargs


### PR DESCRIPTION
I had problem with overriding the default fields in Wagtail 2.12.2. Regardless of what fields I set in `YoastPanel`, like:
```
YoastPanel(
    keywords='keywords',
    title='title',
    search_description='meta_description',
    slug='slug',
)
```
the YOAST panel always worked with default parameters.

I find out, that it is because those parameters are not considered where cloning the `YoastPanel` object.

This PR should fix that.