### PR TITLE
Use importlib.metadata instead of pkg_resources

### DIFF
--- a/wagtailyoast/context.py
+++ b/wagtailyoast/context.py
@@ -1,7 +1,15 @@
 import os
 import json
-import pkg_resources
 from django.conf import settings
+
+try:  # Python 3.8+
+    from importlib.metadata import PackageNotFoundError, version
+except ImportError:  # Python < 3.8
+    from pkg_resources import DistributionNotFound as PackageNotFoundError
+    from pkg_resources import get_distribution
+
+    def version(distribution_name):
+        return get_distribution(distribution_name).version
 
 # =======================================
 # Context variables passed for javascript
@@ -9,8 +17,8 @@ from django.conf import settings
 
 try:
     #  Production part
-    VERSION = pkg_resources.get_distribution("wagtailyoast").version
-except pkg_resources.DistributionNotFound:
+    VERSION = version("wagtailyoast")
+except PackageNotFoundError:
     #  Develop part
     with open(os.path.join(settings.BASE_DIR, 'package.json')) as package:
         data = json.load(package)


### PR DESCRIPTION
setuptools **82.0.0 removed `pkg_resources`**, so on any environment with a current setuptools:

```pycon
>>> import wagtailyoast.context
ModuleNotFoundError: No module named 'pkg_resources'
```

The import is unconditional and at module level in `wagtailyoast/context.py`, and `wagtail_hooks.py` does `from . import context`. Wagtail auto-loads `wagtail_hooks` for every app in `INSTALLED_APPS` during startup, so this brings the entire site down rather than degrading one panel.

`pkg_resources` is used for exactly one thing here: reading the package's own version. `importlib.metadata.version()` is the direct replacement.

### Compatibility

`importlib.metadata` is stdlib from **Python 3.8**. Your `setup.py` classifiers still list 3.6 and 3.7, so I kept a fallback to `pkg_resources` on `ImportError` rather than silently dropping that support. **No new dependency is introduced.**

`DistributionNotFound` is aliased to `PackageNotFoundError` so the existing develop-mode fallback — the one that reads the version out of `package.json` — keeps working exactly as before, on both paths.

If you have dropped Python < 3.8 since, I am happy to reduce this to the plain stdlib import — just say the word.

### Verified

Both paths were exercised against the installed 0.0.10 distribution: each yields `VERSION == "0.0.10"`, and the aliased exception still catches a missing distribution so the `package.json` develop fallback triggers correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)