### PR TITLE
Add a basic test suite and GitHub Actions CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,44 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install flake8
+        run: pip install "flake8>=3.8.3"
+      - name: Run flake8
+        run: flake8
+
+  tests:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - python-version: "3.9"
+            wagtail: ">=5.2,<5.3"
+          - python-version: "3.11"
+            wagtail: ">=6.3,<6.4"
+          - python-version: "3.12"
+            wagtail: ">=7.0"
+          - python-version: "3.13"
+            wagtail: ">=7.0"
+    name: tests (py${{ matrix.python-version }}, wagtail${{ matrix.wagtail }})
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install package and Wagtail
+        run: pip install "wagtail${{ matrix.wagtail }}" -e .
+      - name: Run tests
+        run: python -m django test --settings=test_settings -v 2

--- a/test_settings.py
+++ b/test_settings.py
@@ -1,0 +1,44 @@
+"""Minimal settings for running the wagtailyoast test suite.
+
+Deliberately independent from settings.py, which configures the manual
+demo project (the ``tests`` app) rather than an automated test run.
+"""
+import os
+
+BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+
+DEBUG = True
+SECRET_KEY = "test-only-secret-key"
+USE_TZ = True
+
+# The suite itself is SimpleTestCase-only, but Wagtail 5.2's system
+# checks run a real ContentType query (GroupPagePermission.check ->
+# _migrate_permission_type), so a connectable database must exist.
+DATABASES = {
+    "default": {
+        "ENGINE": "django.db.backends.sqlite3",
+        "NAME": ":memory:",
+    },
+}
+
+INSTALLED_APPS = [
+    "django.contrib.contenttypes",
+    "django.contrib.auth",
+    "django.contrib.staticfiles",
+    "wagtail",
+    "wagtail.admin",
+    "wagtail.users",
+    "wagtail.sites",
+    "wagtailyoast",
+]
+
+TEMPLATES = [
+    {
+        "BACKEND": "django.template.backends.django.DjangoTemplates",
+        "APP_DIRS": True,
+    },
+]
+
+STATIC_URL = "/static/"
+
+WY_LOCALE = "en_US"

--- a/test_wagtailyoast.py
+++ b/test_wagtailyoast.py
@@ -1,0 +1,88 @@
+"""Smoke tests for the wagtailyoast package.
+
+These cover the import chain Wagtail exercises at startup
+(``wagtail_hooks`` -> ``context``) and the two editor hooks. VERSION is
+interpolated into the static asset filenames, so a wrong value does not
+just mislabel the package - it 404s the editor's JS and CSS.
+
+Run with:
+
+    python -m django test --settings=test_settings
+"""
+import importlib
+import json
+import os
+from importlib.metadata import version as installed_version
+from unittest import mock
+
+from django.conf import settings
+from django.test import SimpleTestCase
+
+from wagtailyoast import context, wagtail_hooks
+from wagtailyoast.edit_handlers import YoastPanel
+
+
+class ContextTests(SimpleTestCase):
+
+    def test_version_matches_installed_distribution(self):
+        self.assertEqual(context.VERSION, installed_version("wagtailyoast"))
+
+    def test_locale_comes_from_settings(self):
+        self.assertEqual(context.LOCALE, settings.WY_LOCALE)
+
+    def test_static_url_comes_from_settings(self):
+        self.assertEqual(context.STATIC_URL, settings.STATIC_URL)
+
+    def test_package_json_fallback_when_distribution_is_missing(self):
+        """The develop-mode path: no installed distribution -> package.json."""
+        from importlib.metadata import PackageNotFoundError
+
+        with mock.patch(
+            "importlib.metadata.version",
+            side_effect=PackageNotFoundError("wagtailyoast"),
+        ):
+            reloaded = importlib.reload(context)
+            with open(os.path.join(settings.BASE_DIR, "package.json")) as f:
+                expected = json.load(f)["version"]
+            self.assertEqual(reloaded.VERSION, expected)
+
+        # Restore the real module state for the other tests.
+        importlib.reload(context)
+
+
+class EditorHookTests(SimpleTestCase):
+
+    def test_js_hook_includes_versioned_worker_and_analysis_scripts(self):
+        html = wagtail_hooks.yoast_panel_js()
+        self.assertIn("yoastworker%s.js" % context.VERSION, html)
+        self.assertIn("yoastanalysis%s.js" % context.VERSION, html)
+
+    def test_js_hook_passes_context_to_the_panel(self):
+        html = wagtail_hooks.yoast_panel_js()
+        self.assertIn("new Yoast.Panel(", html)
+        self.assertIn(json.dumps(context.VERSION), html)
+        self.assertIn(json.dumps(context.LOCALE), html)
+
+    def test_css_hook_includes_versioned_stylesheet(self):
+        html = wagtail_hooks.yoast_panel_css()
+        self.assertIn("styles%s.css" % context.VERSION, html)
+
+
+class YoastPanelTests(SimpleTestCase):
+
+    def test_panel_instantiates_with_defaults(self):
+        panel = YoastPanel()
+        self.assertEqual(panel.heading, "Yoast")
+        self.assertEqual(panel.title_field, "seo_title")
+        self.assertEqual(panel.search_description, "search_description")
+        self.assertEqual(panel.slug, "slug")
+
+    def test_clone_kwargs_round_trips_custom_fields(self):
+        panel = YoastPanel(
+            keywords="kw", title="custom_title",
+            search_description="custom_desc", slug="custom_slug",
+        )
+        kwargs = panel.clone_kwargs()
+        self.assertEqual(kwargs["title"], "custom_title")
+        self.assertEqual(kwargs["search_description"], "custom_desc")
+        self.assertEqual(kwargs["slug"], "custom_slug")


### PR DESCRIPTION
This repository has never had automated testing: no `.github` directory, zero Actions runs, and the `tests/` directory is a manual demo app (a `TestPage` model served via `make start`) rather than a test suite — one that today cannot boot at all on the Wagtail versions the package supports, since it still imports `wagtail.core.*` and `wagtail.admin.edit_handlers` (removed in Wagtail 5).

This PR adds a small suite plus a GitHub Actions workflow, so changes like #11 get validated instead of merged on faith.

### What the tests cover

Nine tests, focused on the paths where breakage actually hurts:

- **The startup import chain** (`wagtail_hooks` → `context`). Wagtail auto-loads `wagtail_hooks` for every installed app, so an import error here takes the whole site down — this is exactly where the `pkg_resources` bug that #11 fixes manifests.
- **`VERSION` resolution**, including the develop-mode `package.json` fallback. `VERSION` is interpolated into the static asset filenames (`yoastworker0.0.10.js`, `styles0.0.10.css`), so a wrong value doesn't just mislabel the package — it 404s the editor's JS and CSS.
- **Both editor hooks' HTML output** (versioned script/stylesheet tags, panel context JSON).
- **`YoastPanel` construction and `clone_kwargs` round-tripping**, which Wagtail relies on when cloning panel definitions.

They run against a dedicated minimal `test_settings.py` rather than the demo project's `settings.py` (see above — the demo can't boot on supported Wagtail). One non-obvious detail baked in: Wagtail **5.2**'s system checks execute a real `ContentType` query (`GroupPagePermission.check` → `_migrate_permission_type`), so the settings configure an in-memory sqlite even though the suite itself is `SimpleTestCase`-only.

### The workflow

- flake8, using the repo's existing `.flake8` config (clean today);
- the suite on Wagtail 5.2 / 6.3 / 7.x across Python 3.9–3.13;
- triggers on push, pull_request and manual dispatch.

### Verified before opening

Both configurations ran on a fork:

| | py3.9 / w5.2 | py3.11 / w6.3 | py3.12 / w7 | py3.13 / w7 | lint |
|---|---|---|---|---|---|
| [with #11's fix](https://github.com/PetrDlouhy/wagtailyoast/actions/runs/30350684695) | ✅ | ✅ | ✅ | ✅ | ✅ |
| [current master](https://github.com/PetrDlouhy/wagtailyoast/actions/runs/30350684418) | ✅ | ✅ | ❌ | ❌ | ✅ |

The two failures on current master are `ModuleNotFoundError: No module named 'pkg_resources'` — the suite catches precisely the bug #11 fixes, on the Pythons whose environments no longer ship setuptools. (3.9/3.11 runners still carry setuptools, which is why master survives there.)

So the expected sequence: this PR's checks will show those two red cells against master — that is the bug being documented, not the CI being broken. Once #11 lands, everything is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
