### PR TITLE
Fix panel rendering on the post-4.0 Wagtail panels API

### DIFF
--- a/test_wagtailyoast.py
+++ b/test_wagtailyoast.py
@@ -16,10 +16,28 @@ from importlib.metadata import version as installed_version
 from unittest import mock
 
 from django.conf import settings
-from django.test import SimpleTestCase
+from django.contrib.auth.models import AnonymousUser
+from django.db import models
+from django.test import RequestFactory, SimpleTestCase
+
+from wagtail.models import Page
 
 from wagtailyoast import context, wagtail_hooks
 from wagtailyoast.edit_handlers import YoastPanel
+
+
+class ProbeModel(models.Model):
+    """Minimal model exposing the `keywords` field YoastPanel expects.
+
+    Test-only; never migrated or saved. A plain model (not a Page
+    subclass) keeps the migration-less test app out of Django's
+    migration state, and the panel machinery is model-agnostic.
+    """
+
+    keywords = models.CharField(max_length=255, blank=True, default="")
+
+    class Meta:
+        app_label = "wagtailyoast"
 
 
 class ContextTests(SimpleTestCase):
@@ -86,3 +104,56 @@ class YoastPanelTests(SimpleTestCase):
         self.assertEqual(kwargs["title"], "custom_title")
         self.assertEqual(kwargs["search_description"], "custom_desc")
         self.assertEqual(kwargs["slug"], "custom_slug")
+
+
+class YoastPanelRenderTests(SimpleTestCase):
+    """The panel must render its own template, not a plain ObjectList.
+
+    Wagtail's post-4.0 panels API ignores the legacy class-level
+    `template` attribute, which left the panel rendering as a bare
+    ObjectList (no #yoast_panel markup for the JS to attach to) on
+    every modern Wagtail - the breakage reported in issue #8.
+    """
+
+    def _bound_panel(self):
+        panel_def = YoastPanel().bind_to_model(ProbeModel)
+        form_class = panel_def.get_form_class()
+        instance = ProbeModel()
+        form = form_class(instance=instance)
+        request = RequestFactory().get("/")
+        request.user = AnonymousUser()
+        return panel_def.get_bound_panel(
+            instance=instance, request=request, form=form,
+        )
+
+    def test_bound_panel_uses_the_yoast_template(self):
+        bound = self._bound_panel()
+        self.assertEqual(
+            bound.template_name,
+            "wagtailyoast/edit_handlers/yoast_panel.html",
+        )
+
+    def test_rendered_panel_contains_the_yoast_markup(self):
+        html = str(self._bound_panel().render_html({}))
+        self.assertIn('id="yoast_panel"', html)
+        self.assertIn('id="yoast_title" data-field="seo_title"', html)
+        self.assertIn(
+            'id="yoast_search_description"'
+            ' data-field="search_description"',
+            html,
+        )
+        self.assertIn('id="yoast_slug" data-field="slug"', html)
+        self.assertIn('id="yoast_results_seo"', html)
+        self.assertIn('id="yoast_results_readability"', html)
+
+    def test_rendered_panel_contains_the_keywords_form_field(self):
+        html = str(self._bound_panel().render_html({}))
+        self.assertIn('id="yoast_keywords"', html)
+
+    def test_clone_preserves_a_custom_keywords_field(self):
+        """clone_kwargs dropped `keywords`, so binding rebuilt the
+        panel against the default field name and crashed on any model
+        without a literal `keywords` field."""
+        panel_def = YoastPanel(keywords="seo_title").bind_to_model(Page)
+        form_class = panel_def.get_form_class()
+        self.assertIn("seo_title", form_class.base_fields)

--- a/wagtailyoast/edit_handlers.py
+++ b/wagtailyoast/edit_handlers.py
@@ -4,7 +4,6 @@ from wagtail.admin.panels import FieldPanel, MultiFieldPanel
 
 
 class YoastPanel(ObjectList):
-    template = "wagtailyoast/edit_handlers/yoast_panel.html"
 
     def __init__(self, keywords='keywords', title='seo_title',
                  search_description='search_description', slug='slug',
@@ -20,6 +19,7 @@ class YoastPanel(ObjectList):
         """
         #  TODO: Test if fields exist
 
+        self.keywords = keywords
         self.title_field = title
         self.search_description = search_description
         self.slug = slug
@@ -36,7 +36,11 @@ class YoastPanel(ObjectList):
 
     def clone_kwargs(self):
         kwargs = super().clone_kwargs()
+        kwargs['keywords'] = self.keywords
         kwargs['title'] = self.title_field
         kwargs['search_description'] = self.search_description
         kwargs['slug'] = self.slug
         return kwargs
+
+    class BoundPanel(ObjectList.BoundPanel):
+        template_name = "wagtailyoast/edit_handlers/yoast_panel.html"

--- a/wagtailyoast/templates/wagtailyoast/edit_handlers/yoast_panel.html
+++ b/wagtailyoast/templates/wagtailyoast/edit_handlers/yoast_panel.html
@@ -2,13 +2,13 @@
 
     {% comment %} Panel Form {% endcomment %}
 
-    {% include 'wagtailadmin/edit_handlers/object_list.html' %}
+    {% include 'wagtailadmin/panels/object_list.html' %}
 
     {% comment %} Pass YoastPanel fields to javascript {% endcomment %}
 
-    <div id="yoast_title" data-field="{{ self.title_field }}"></div>
-    <div id="yoast_search_description" data-field="{{ self.search_description }}"></div>
-    <div id="yoast_slug" data-field="{{ self.slug }}"></div>
+    <div id="yoast_title" data-field="{{ self.panel.title_field }}"></div>
+    <div id="yoast_search_description" data-field="{{ self.panel.search_description }}"></div>
+    <div id="yoast_slug" data-field="{{ self.panel.slug }}"></div>
 
     {% comment %} Include results of Yoast {% endcomment %}
 


### PR DESCRIPTION
The panel — the package's entire purpose — has not actually rendered on any modern Wagtail, silently, since the panels API rework in **Wagtail 4.0**. This is the breakage reported in #8 ("the SEO panel isn't rendering", no console errors).

### Root cause

`YoastPanel` set a class-level `template` attribute. The post-4.0 panels API reads `BoundPanel.template_name` instead and **silently ignores** `template` — so the panel rendered as a plain `ObjectList`: form fields only, no `#yoast_panel` wrapper, no `yoast_title`/`yoast_search_description`/`yoast_slug` data divs, no result containers. The Yoast JS then had nothing to attach to. No error is raised anywhere, which is why this was so hard to diagnose from the outside.

Verified empirically before the fix: on both Wagtail 5.2 and 7.4, the bound panel's `template_name` was the stock `wagtailadmin/panels/object_list.html`.

### The fix

- A `BoundPanel` subclass carrying `template_name` (the modern mechanism);
- the template updated for the modern context — `self` is now the *bound* panel, so definition attributes hang off `self.panel.*` — and the modern include path (`wagtailadmin/panels/object_list.html`; the `edit_handlers/` one was removed with the old API).

### A second, latent bug found while testing

`clone_kwargs()` never preserved `keywords`, and `bind_to_model()` clones the panel — so a customised keywords field was silently discarded and the panel crashed with `FieldError` on any model without a field literally named `keywords`. One line in `clone_kwargs` fixes it, with a regression test.

### Tests

Four new render-level tests (bound `template_name`, full Yoast markup in the rendered HTML, the keywords form field, clone round-trip). They **fail against the previous code** and pass with the fix. Full suite: 13/13 on Wagtail 5.2 and 7.4 locally, and [all green on the fork CI matrix](https://github.com/PetrDlouhy/wagtailyoast/actions/runs/30355908397) (Wagtail 5.2/6.3/7.x × Python 3.9–3.13).

### Honest scope note

This makes the panel *render* again, verified at the HTML level. In-browser behaviour (the bundled `yoastseo` engine, the `$(...)` bootstrap in the editor) is not covered by these tests and deserves a manual check in a real admin session before a release is announced as fully working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
