### PR TITLE
Add a tag-triggered release build workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,85 @@
+name: Release
+
+# Builds the frontend assets and the Python package, and publishes to
+# PyPI when a version tag is pushed (e.g. v0.0.11, as created by
+# `npm version patch`).
+#
+# Publishing uses PyPI Trusted Publishing (OIDC) - no tokens or secrets
+# are stored anywhere. One-time setup by the PyPI project owner:
+# add a "trusted publisher" on pypi.org for this repository with
+# workflow name release.yml (Manage project -> Publishing).
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # Node 12 is intentional: the asset pipeline pins node-sass
+      # 4.13.1, whose prebuilt bindings stop at Node 13 (building it
+      # from source needs Python 2). Node 12 is the newest runtime
+      # with working prebuilt bindings. If actions/setup-node ever
+      # drops Node 12, the pipeline needs porting to dart-sass first.
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "12"
+
+      - name: Install JS dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Build versioned frontend assets
+        run: yarn build
+
+      - name: Check built assets match package.json version
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          DIST=wagtailyoast/static/wagtailyoast/dist
+          test -f "$DIST/js/yoastworker$VERSION.js"
+          test -f "$DIST/js/yoastanalysis$VERSION.js"
+          test -f "$DIST/css/styles$VERSION.css"
+          COUNT=$(find "$DIST" -type f | wc -l)
+          echo "dist contains $COUNT files for version $VERSION"
+          find "$DIST" -type f | grep -v "$VERSION" && {
+            echo "ERROR: dist contains files from other versions"; exit 1;
+          } || true
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Build the Python package
+        run: |
+          pip install build twine
+          python -m build
+          twine check dist/*
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  publish:
+    needs: build
+    # Publish only for real version tags on the upstream repository -
+    # forks can run the build job for verification without touching
+    # PyPI.
+    if: >-
+      startsWith(github.ref, 'refs/tags/v') &&
+      github.repository == 'Aleksi44/wagtailyoast'
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish to PyPI (trusted publishing)
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,13 +1,16 @@
-name: Release
+name: Release build
 
-# Builds the frontend assets and the Python package, and publishes to
-# PyPI when a version tag is pushed (e.g. v0.0.11, as created by
-# `npm version patch`).
+# Builds the versioned frontend assets and the Python package for a
+# release, and uploads them as a workflow artifact. Publishing stays
+# exactly as it is today: download the `dist` artifact and run
+# `twine upload dist/*` with your own PyPI credentials, from any
+# machine - no Node toolchain needed anymore.
 #
-# Publishing uses PyPI Trusted Publishing (OIDC) - no tokens or secrets
-# are stored anywhere. One-time setup by the PyPI project owner:
-# add a "trusted publisher" on pypi.org for this repository with
-# workflow name release.yml (Manage project -> Publishing).
+# (If zero-touch publishing is ever wanted, this can be extended with
+# a publish job using PyPI Trusted Publishing - a tokenless, UI-only
+# authorisation on pypi.org. Deliberately not included here so that
+# nothing about how this package is published changes without the
+# owner deciding it should.)
 
 on:
   push:
@@ -63,23 +66,3 @@ jobs:
         with:
           name: dist
           path: dist/
-
-  publish:
-    needs: build
-    # Publish only for real version tags on the upstream repository -
-    # forks can run the build job for verification without touching
-    # PyPI.
-    if: >-
-      startsWith(github.ref, 'refs/tags/v') &&
-      github.repository == 'Aleksi44/wagtailyoast'
-    runs-on: ubuntu-latest
-    permissions:
-      id-token: write
-    steps:
-      - uses: actions/download-artifact@v4
-        with:
-          name: dist
-          path: dist/
-
-      - name: Publish to PyPI (trusted publishing)
-        uses: pypa/gh-action-pypi-publish@release/v1

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,6 @@
 include *.rst
 include AUTHORS
+include package.json
 include LICENSE
 recursive-include wagtailyoast/templates *.html
 recursive-include wagtailyoast/static *


### PR DESCRIPTION
Adds a tag-triggered **build** workflow, so that preparing a release no longer depends on a maintainer machine with a working 2020-era Node toolchain. **Nothing about publishing changes** — you release exactly as today, with your own PyPI credentials; this just makes the artifacts buildable again.

### Why CI is now the only place this build works

`yarn install` fails on any current machine: node-sass 4.13.1 has no prebuilt bindings past **Node 13**, and compiling it from source requires **Python 2**. I probed Node 12/14/16 on a fork — [only Node 12 builds](https://github.com/PetrDlouhy/wagtailyoast/actions/runs/30354429007), via the prebuilt bindings. The workflow pins Node 12 with a comment explaining why, and what to do when `setup-node` eventually drops it (port to dart-sass).

### What it does

On a `v*` tag (exactly what `npm version patch` / `make patch` already creates), or manual dispatch:

1. **Node 12** → `yarn install --frozen-lockfile` → `yarn build` (versioned assets);
2. **sanity gate**: `dist/` must contain the current `package.json` version's worker/analysis/styles — and *nothing from any other version* (permanently guards the accumulation bug from #7 / #13);
3. `python -m build` + `twine check`;
4. upload `dist/` as a workflow artifact.

Releasing is then: download the artifact, `twine upload dist/*` — from any machine, no Node required. (If you ever want zero-touch publishing, this can be extended with a publish job using PyPI [trusted publishing](https://docs.pypi.org/trusted-publishers/) — tokenless, one UI-only authorisation on pypi.org. Deliberately **not** included here: how this package is published is your call, and until that authorisation existed a publish job would fail red on every tag you push.)

### One packaging fix included

`setup.py` reads the version from `./package.json`, but `MANIFEST.in` never shipped that file — so **every published sdist is currently unbuildable** (`pip install` from the sdist fails with `FileNotFoundError`; unnoticed because pip always prefers the universal wheel, and the old `setup.py sdist bdist_wheel` flow built both from the working directory). `python -m build` builds the wheel *from* the sdist, which surfaced it. One `include package.json` line fixes the sdist for good.

### Verified on a fork

[Full run](https://github.com/PetrDlouhy/wagtailyoast/actions/runs/30356204833) with a test tag: assets built on Node 12, the single-version gate passed ("dist contains 4 files for version 0.0.10"), `twine check` passed, and the artifact came out at 2.6 MB — versus ~39 MB of accumulated assets in the current 0.0.10 wheel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
