### PR TITLE
Collect coverage in CI

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,14 @@
+[run]
+# Measure the package only - not the test suite or the test-only app.
+source = wagtailyoast
+branch = true
+
+[report]
+show_missing = true
+skip_covered = false
+# Fail below the level the suite currently reaches, so a drop is loud.
+# The shortfall from 100% is context.py's pre-3.8 import fallback,
+# which no Python in the CI matrix (3.9+) can reach.
+fail_under = 90
+exclude_lines =
+    pragma: no cover

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,6 +39,8 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install package and Wagtail
-        run: pip install "wagtail${{ matrix.wagtail }}" -e .
-      - name: Run tests
-        run: python -m django test --settings=test_settings -v 2
+        run: pip install "wagtail${{ matrix.wagtail }}" coverage -e .
+      - name: Run tests under coverage
+        run: coverage run -m django test --settings=test_settings -v 2
+      - name: Coverage report
+        run: coverage report


### PR DESCRIPTION
Runs the test suite under `coverage` on every matrix cell and prints the per-file report in the job log, so coverage is visible on every run and per Wagtail/Python combination.

```
Name                            Stmts   Miss Branch BrPart  Cover   Missing
---------------------------------------------------------------------------
wagtailyoast/__init__.py            0      0      0      0   100%
wagtailyoast/context.py            18      5      0      0    72%   7-12
wagtailyoast/edit_handlers.py      20      0      0      0   100%
wagtailyoast/wagtail_hooks.py      17      0      0      0   100%
---------------------------------------------------------------------------
TOTAL                              55      5      0      0    91%
```

### Why no coverage service

The package is **55 statements**. A hosted dashboard would mean an integration to keep working — plus a new way for builds to go red for reasons unrelated to the code — in exchange for a number that fits in four lines of log output. It would also need repository-admin setup, whereas this works the moment it merges.

`.coveragerc` carries a `fail_under` threshold instead, so a regression fails the build without depending on anything outside the repository. Verified the gate actually bites: at `fail_under = 95` the report exits non-zero, at `90` it exits `0`.

### About the missing 9%

`context.py` lines 7–12 are the `except ImportError` fallback for Python < 3.8:

```python
try:  # Python 3.8+
    from importlib.metadata import PackageNotFoundError, version
except ImportError:  # Python < 3.8
    ...
```

No Python in the CI matrix (3.9+) can execute it, so it is structurally unreachable rather than untested. There is a case for deleting the fallback outright — the matrix starts at 3.9 and Wagtail 5.2+ requires 3.8+, so it is arguably dead weight — but that narrows declared support (`setup.py` still lists 3.6/3.7), which is a policy decision and deliberately not bundled here.

The threshold is set at 90, just under the current 91%, so it catches regressions without flagging that structural gap.

### Notes

- Based on master rather than #16, so it can merge first; the two touch different files and do not conflict. Once #16 lands, coverage rises above 91% since its admin-level tests exercise the hooks and panel end to end.
- `.gitignore` already covers `.coverage*` and `htmlcov/`.
- [Green across the matrix](https://github.com/PetrDlouhy/wagtailyoast/actions/runs/30435437332) (Wagtail 5.2 / 6.3 / 7.x × Python 3.9–3.13), with the report visible in each job log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
