### PR TITLE
Port the demo project to modern Wagtail, and smoke-test it in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,3 +44,36 @@ jobs:
         run: coverage run -m django test --settings=test_settings -v 2
       - name: Coverage report
         run: coverage report
+
+  demo:
+    # The demo project (settings.py + the `tests` app) is the dev
+    # environment the README documents. It is not shipped to users, but
+    # it rotted unnoticed for years - every module still imported
+    # `wagtail.core`, removed in Wagtail 5 - so `manage.py migrate`
+    # crashed for anyone following the README. This job keeps it honest.
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - python-version: "3.9"
+            wagtail: ">=5.2,<5.3"
+          - python-version: "3.13"
+            wagtail: ">=7.0"
+    name: demo project (py${{ matrix.python-version }}, wagtail${{ matrix.wagtail }})
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install package and demo requirements
+        run: pip install "wagtail${{ matrix.wagtail }}" requests -e .
+      - name: Migrate the demo project
+        run: python manage.py migrate --noinput
+      - name: Run system checks
+        run: python manage.py check
+      - name: Load the seed command
+        # `init` itself downloads a mock image, so it is not run here -
+        # a network hiccup should not fail CI. Loading the command still
+        # catches import-level breakage in tests/management and tests/blocks.
+        run: python manage.py help init > /dev/null

--- a/conf/django.py
+++ b/conf/django.py
@@ -30,7 +30,7 @@ INSTALLED_APPS = [
     'wagtail.images',
     'wagtail.search',
     'wagtail.admin',
-    'wagtail.core',
+    'wagtail',
     'wagtail.contrib.settings',
     'wagtail.contrib.frontend_cache',
     'taggit',
@@ -78,6 +78,7 @@ TEMPLATES = [
 
 SITE_ID = 1
 WAGTAIL_SITE_NAME = 'Wagtail Yoast'
+WAGTAILADMIN_BASE_URL = 'http://localhost:4243'
 ROOT_URLCONF = 'urls'
 
 STATICFILES_FINDERS = [
@@ -85,7 +86,6 @@ STATICFILES_FINDERS = [
     'django.contrib.staticfiles.finders.AppDirectoriesFinder',
 ]
 
-STATICFILES_DIRS = [os.path.join(BASE_DIR, 'static')]
 STATIC_ROOT = os.path.join(BASE_DIR, 'staticfiles')
 STATIC_URL = '/static/'
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ django>=4.2
 wagtail>=5.2
 flake8>=3.8.3
 coverage
+requests

--- a/tests/blocks.py
+++ b/tests/blocks.py
@@ -2,7 +2,7 @@ import requests
 from io import BytesIO
 from django.core.files.images import ImageFile
 from wagtail.images.blocks import ImageChooserBlock
-from wagtail.core.blocks import RichTextBlock
+from wagtail.blocks import RichTextBlock
 from wagtail.images.models import Image
 
 from . import constants

--- a/tests/management/commands/init.py
+++ b/tests/management/commands/init.py
@@ -2,7 +2,7 @@ import json
 from django.contrib.auth.models import Group, User
 from django.core.management.base import BaseCommand
 from django.contrib.contenttypes.models import ContentType
-from wagtail.core.models import Page, Site
+from wagtail.models import Page, Site
 from wagtail.images.models import Image
 
 from tests.models import TestPage

--- a/tests/migrations/0001_initial.py
+++ b/tests/migrations/0001_initial.py
@@ -3,7 +3,7 @@
 from django.db import migrations, models
 import django.db.models.deletion
 import tests.blocks
-import wagtail.core.fields
+import wagtail.fields
 
 
 class Migration(migrations.Migration):
@@ -19,7 +19,7 @@ class Migration(migrations.Migration):
             name='TestPage',
             fields=[
                 ('page_ptr', models.OneToOneField(auto_created=True, on_delete=django.db.models.deletion.CASCADE, parent_link=True, primary_key=True, serialize=False, to='wagtailcore.Page')),
-                ('body', wagtail.core.fields.StreamField([('text', tests.blocks.TextBlock()), ('image', tests.blocks.ImageBlock())], blank=True)),
+                ('body', wagtail.fields.StreamField([('text', tests.blocks.TextBlock()), ('image', tests.blocks.ImageBlock())], blank=True)),
                 ('keywords', models.CharField(blank=True, default='', max_length=100)),
             ],
             options={

--- a/tests/models.py
+++ b/tests/models.py
@@ -1,9 +1,9 @@
 from django.db import models
 from django.utils.translation import gettext_lazy
-from wagtail.core.fields import StreamField
-from wagtail.core.models import Page
-from wagtail.admin.edit_handlers import StreamFieldPanel
-from wagtail.admin.edit_handlers import TabbedInterface, ObjectList
+from wagtail.fields import StreamField
+from wagtail.models import Page
+from wagtail.admin.panels import FieldPanel
+from wagtail.admin.panels import TabbedInterface, ObjectList
 
 from wagtailyoast.edit_handlers import YoastPanel
 
@@ -19,12 +19,12 @@ class TestPage(Page):
     body = StreamField([
         ('text', TextBlock()),
         ('image', ImageBlock()),
-    ], blank=True)
+    ], blank=True, use_json_field=True)
     keywords = models.CharField(default='', blank=True, max_length=100)
 
     edit_handler = TabbedInterface([
         ObjectList(
-            Page.content_panels + [StreamFieldPanel('body')],
+            Page.content_panels + [FieldPanel('body')],
             heading=gettext_lazy('Content')
         ),
         ObjectList(Page.promote_panels, heading=gettext_lazy('Promotion')),

--- a/urls.py
+++ b/urls.py
@@ -1,12 +1,13 @@
 from django.conf import settings
-from django.conf.urls import include, url
-from django.contrib import admin
 from django.conf.urls.static import static
+from django.contrib import admin
+from django.urls import include, re_path
+
+from wagtail import urls as wagtail_urls
 from wagtail.admin import urls as wagtailadmin_urls
-from wagtail.core import urls as wagtail_urls
 
 urlpatterns = [
-    url(r'^admin', admin.site.urls),
-    url(r'^wagtail/', include(wagtailadmin_urls)),
-    url(r"^", include(wagtail_urls)),
+    re_path(r'^admin', admin.site.urls),
+    re_path(r'^wagtail/', include(wagtailadmin_urls)),
+    re_path(r"^", include(wagtail_urls)),
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)


### PR DESCRIPTION
The demo project — `settings.py` plus the `tests` app — is the development environment the README documents (lines 74–90). It has been dead for years: every module still imported `wagtail.core`, removed in **Wagtail 5.0**.

```console
$ python manage.py migrate
ModuleNotFoundError: No module named 'wagtail.core'
```

Identical on **Wagtail 5.2 and 7.4** — both ends of the range the package supports. So anyone accepting the "PRs are welcome" invitation in #8 hit a wall in their first minute.

### The port

| | from | to |
|---|---|---|
| `conf/django.py`, `urls.py`, `tests/*` | `wagtail.core.*` | `wagtail.*` |
| `tests/models.py` | `wagtail.admin.edit_handlers` | `wagtail.admin.panels` |
| `tests/models.py` | `StreamFieldPanel('body')` | `FieldPanel('body')` |
| `tests/models.py` | `StreamField([...])` | `StreamField([...], use_json_field=True)` |
| `urls.py` | `django.conf.urls.url` | `django.urls.re_path` |

`django.conf.urls.url` was removed in Django 4.0, so there was a second layer of rot underneath the Wagtail one. `use_json_field` was checked against the actual `StreamField` signature on 5.2 and 7.4 rather than assumed.

### Verified working, not just importing

- `migrate`, `check` and `init` all succeed on Wagtail 5.2 and 7.4;
- `init` seeds its three demo pages and the admin user;
- driving the demo's own admin in a headless browser shows the Yoast panel with **7 SEO results rendered and zero JS errors** — the demo now demonstrates the thing it exists to demonstrate.

### The CI job

A `demo` job runs `migrate`, `check` and loads the `init` command on the oldest and newest supported combinations, so this cannot rot silently again.

`init` itself is deliberately **not** run: it downloads a mock image from `media.wagtail.io`, and a network hiccup should not turn CI red. Loading the command still catches import-level breakage in `tests/management` and `tests/blocks`.

Confirmed the job actually catches the original rot, by restoring it one file at a time:

| Restored | Failing step |
|---|---|
| `wagtail.core` in `conf/django.py` | `migrate` |
| `wagtail.core` in `tests/management/commands/init.py` | load `init` |

### Two smaller fixes

- **`requests`** is imported at module level by `tests/blocks.py` but was never declared — it happened to arrive transitively via Wagtail. Now in `requirements.txt`.
- **Two `check` warnings were the demo's own**: `STATICFILES_DIRS` pointed at a directory that does not exist in the repository, and `WAGTAILADMIN_BASE_URL` was undefined. `manage.py check` is now clean apart from treebeard warnings raised by Wagtail itself.

Nothing here ships to users — `setup.py` excludes `tests` from the distribution (#18) — so this is contributor-facing only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
