### PR TITLE
Bring the README up to date and modernise the deploy target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,11 +10,15 @@ mm:
 superuser:
 	python manage.py createsuperuser
 
+# Requires Node 12 for `yarn build` (node-sass 4.x has no prebuilt
+# bindings for newer runtimes). If your Node is newer, push a version
+# tag instead and download the `dist` artifact built by the Release
+# workflow, then run `python -m twine upload dist/*`.
 deploy:
 	rm -rf dist/*
 	rm -rf wagtailyoast/static/wagtailyoast/dist
 	yarn build
-	python setup.py sdist bdist_wheel
+	python -m build
 	python -m twine upload dist/*
 
 patch:

--- a/README.rst
+++ b/README.rst
@@ -10,11 +10,15 @@ Wagtail Yoast SEO
 
 `Yoastseo <https://github.com/Yoast/javascript/tree/master/packages/yoastseo>`_ + `Wagtail <https://github.com/wagtail/wagtail>`_ = 🚀
 
-Tested with :
+Requirements
+############
 
-- django==3.0.9
-- wagtail==2.10.1
-- yoastseo:1.80.0
+- Python 3.9+
+- Django 4.2+
+- Wagtail 5.2+
+
+Continuously tested against Wagtail 5.2, 6.3 and 7.x on Python 3.9 to
+3.13. Bundles yoastseo 1.80.0.
 
 Setup
 #####
@@ -42,7 +46,7 @@ Add YoastPannel to your Page models :
 
 ::
 
-    from wagtail.admin.edit_handlers import TabbedInterface, ObjectList
+    from wagtail.admin.panels import TabbedInterface, ObjectList
     from wagtailyoast.edit_handlers import YoastPanel
 
 
@@ -98,4 +102,31 @@ Run Webpack Server
     yarn
     yarn start
 
+
+Changelog
+#########
+
+0.0.11 (unreleased)
+*******************
+
+- Fix ``ModuleNotFoundError: No module named 'pkg_resources'`` at Django
+  startup on setuptools 82 and later, which removed ``pkg_resources``.
+- Fix the panel not rendering on Wagtail 4.0 and later: the panels API
+  introduced there ignores the legacy class-level ``template``
+  attribute, so the panel silently degraded to a plain ``ObjectList``.
+- Fix the panel stylesheet never loading: it was registered on
+  ``insert_editor_css``, a hook Wagtail no longer renders.
+- Fix a custom ``keywords`` field being discarded when Wagtail clones
+  the panel, which raised ``FieldError`` on models without a field of
+  that literal name.
+- Declare runtime dependencies. ``install_requires`` was empty, so
+  ``pip install wagtailyoast`` pulled in neither Django nor Wagtail and
+  the package failed at import.
+- Declare ``python_requires`` and refresh the trove classifiers, which
+  advertised Python 3.6-3.8 while the package is tested on 3.9-3.13.
+- Stop shipping every previous release's JavaScript and CSS: packages
+  contained the built assets of all versions since 0.0.1, roughly 39 MB
+  where one version's assets are about 5 MB.
+- Add a test suite and continuous integration across Wagtail 5.2, 6.3
+  and 7.x on Python 3.9 to 3.13.
 


### PR DESCRIPTION
Three documentation and tooling leftovers, one of which is not cosmetic.

### The integration example was broken

The README tells users to write this as the very first step of adding the panel:

```python
from wagtail.admin.edit_handlers import TabbedInterface, ObjectList
```

`wagtail.admin.edit_handlers` was removed in **Wagtail 5**, so anyone copying the documented example hit `ModuleNotFoundError` before writing a line of their own code. It now uses `wagtail.admin.panels`, and I checked the corrected snippet actually imports on both Wagtail 5.2 and 7.4 rather than swapping one broken example for another.

### Requirements

The "Tested with" block still claimed:

```
- django==3.0.9
- wagtail==2.10.1
```

Replaced with a Requirements section stating the floors `setup.py` now declares (Python 3.9+, Django 4.2+, Wagtail 5.2+) and what CI actually exercises (Wagtail 5.2 / 6.3 / 7.x on Python 3.9–3.13).

### Changelog

The project had no release history anywhere, so the 0.0.11 changes would have existed only in PR descriptions. Added a Changelog section covering them: the `pkg_resources` startup crash, the panel not rendering, the stylesheet not loading, the `keywords` clone bug, the missing runtime dependencies, the classifier refresh, the package-size fix, and the new test suite.

### Makefile

`python setup.py sdist bdist_wheel` is deprecated by setuptools, so `deploy` now uses `python -m build`. Added a comment recording that the target needs **Node 12** for `yarn build` (node-sass 4.x has no prebuilt bindings for newer runtimes) and that pushing a version tag and downloading the Release workflow's `dist` artifact is the alternative on a newer Node — so the target documents its own constraint instead of just failing.

### Verified

The README is the package's `long_description`, so a malformed edit would break the PyPI project page or the upload itself:

- the RST parses cleanly;
- `twine check` passes on both the wheel and the sdist;
- `python -m build` (the Makefile's new command) succeeds;
- tests and flake8 unaffected — 17/17 green, 100% coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
